### PR TITLE
Feat/member jwt filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript{
 	ext {
 		springBootVersion = '2.7.6'
+		set('springCloudVersion', '2021.0.1')
 	}
 	repositories {
 		mavenCentral()
@@ -21,6 +22,12 @@ subprojects{
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
 
+	dependencyManagement{
+		imports{
+			mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+		}
+	}
+
 	group = 'com.teamzero'
 	version = '0.0.1-SNAPSHOT'
 	sourceCompatibility = '11'
@@ -40,6 +47,9 @@ subprojects{
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 		implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 		implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+		implementation 'org.springframework.data:spring-data-envers'
+		implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+		implementation 'com.google.code.gson:gson:2.9.0'
 		compileOnly 'org.projectlombok:lombok'
 		runtimeOnly 'com.mysql:mysql-connector-j'
 		annotationProcessor 'org.projectlombok:lombok'

--- a/member-api/build.gradle
+++ b/member-api/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+    implementation(project(path: ':product-api', configuration: 'default'))
 
 }

--- a/member-api/build.gradle
+++ b/member-api/build.gradle
@@ -1,3 +1,5 @@
 dependencies {
+    implementation(project(path: ':product-api', configuration: 'default'))
+    implementation(project(path: ':teamzero-domain', configuration: 'default'))
 
 }

--- a/member-api/src/main/java/com/teamzero/member/UserApplication.java
+++ b/member-api/src/main/java/com/teamzero/member/UserApplication.java
@@ -2,8 +2,14 @@ package com.teamzero.member;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableJpaRepositories
+@EnableFeignClients
 public class UserApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserApplication.class, args);

--- a/member-api/src/main/java/com/teamzero/member/config/GsonConfig.java
+++ b/member-api/src/main/java/com/teamzero/member/config/GsonConfig.java
@@ -1,0 +1,14 @@
+package com.teamzero.member.config;
+
+import com.google.gson.Gson;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GsonConfig {
+    @Bean
+    public Gson gson(){
+        return new Gson();
+    }
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/BaseEntity.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.teamzero.member.domain.model;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime registeredAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/Member.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/Member.java
@@ -1,0 +1,53 @@
+package com.teamzero.member.domain.model;
+
+import com.teamzero.member.domain.model.constants.MemberRole;
+import com.teamzero.member.domain.model.constants.MemberStatus;
+import com.teamzero.member.domain.model.constants.RegisterType;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+public class Member extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    private String email;
+    private String nickname;
+    private String password;
+
+    @Enumerated(value = EnumType.STRING)
+    private RegisterType registerType;
+
+    @Enumerated(value = EnumType.STRING)
+    private MemberRole memberRole;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "id")
+    private MemberGrade memberGrade;
+
+    @Enumerated(value = EnumType.STRING)
+    private MemberStatus memberStatus;
+
+    // 이메일 인증 관련
+    private String emailAuthKey;
+    private boolean emailAuthYn;
+    private LocalDateTime emailAuthExpiredAt;
+
+    // 포인트 관련
+    @Audited
+    private long points; // 보유 포인트
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/MemberEntity.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/MemberEntity.java
@@ -1,0 +1,54 @@
+package com.teamzero.member.domain.model;
+
+import com.teamzero.member.domain.model.constants.MemberRole;
+import com.teamzero.member.domain.model.constants.MemberStatus;
+import com.teamzero.member.domain.model.constants.RegisterType;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+@Table(name = "MEMBER")
+public class MemberEntity extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    private String email;
+    private String nickname;
+    private String password;
+
+    @Enumerated(value = EnumType.STRING)
+    private RegisterType registerType;
+
+    @Enumerated(value = EnumType.STRING)
+    private MemberRole memberRole;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "id")
+    private MemberGradeEntity memberGradeEntity;
+
+    @Enumerated(value = EnumType.STRING)
+    private MemberStatus memberStatus;
+
+    // 이메일 인증 관련
+    private String emailAuthKey;
+    private boolean emailAuthYn;
+    private LocalDateTime emailAuthExpiredAt;
+
+    // 포인트 관련
+    @Audited
+    private long points; // 보유 포인트
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/MemberGrade.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/MemberGrade.java
@@ -1,0 +1,29 @@
+package com.teamzero.member.domain.model;
+
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+public class MemberGrade extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    private Long id;
+
+    private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private int rewardPointPct; // 포인트 적립 비율
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/MemberGradeEntity.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/MemberGradeEntity.java
@@ -1,0 +1,30 @@
+package com.teamzero.member.domain.model;
+
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+@Table(name = "MEMBER_GRADE")
+public class MemberGradeEntity extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    private Long id;
+
+    private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity memberEntity;
+
+    private int rewardPointPct; // 포인트 적립 비율
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/constants/MemberRole.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/constants/MemberRole.java
@@ -1,0 +1,15 @@
+package com.teamzero.member.domain.model.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberRole {
+
+    REGULAR("일반 회원"),
+    ADMIN("관리자");
+
+    private final String description;
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/constants/MemberStatus.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/constants/MemberStatus.java
@@ -1,0 +1,16 @@
+package com.teamzero.member.domain.model.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus {
+
+    NO_AUTH("미인증"),
+    IN_USE("활성화"),
+    WITHDRAW("탈퇴");
+
+    private final String description;
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/model/constants/RegisterType.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/model/constants/RegisterType.java
@@ -1,0 +1,10 @@
+package com.teamzero.member.domain.model.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum RegisterType {
+
+    EMAIL, GOOGLE, NAVER, KAKAO;
+
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/repository/MemberGradeRepository.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/repository/MemberGradeRepository.java
@@ -1,0 +1,7 @@
+package com.teamzero.member.domain.repository;
+
+import com.teamzero.member.domain.model.MemberGradeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberGradeRepository extends JpaRepository<MemberGradeEntity, Long> {
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/repository/MemberGradeRepository.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/repository/MemberGradeRepository.java
@@ -1,0 +1,7 @@
+package com.teamzero.member.domain.repository;
+
+import com.teamzero.member.domain.model.MemberGrade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberGradeRepository extends JpaRepository<MemberGrade, Long> {
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.teamzero.member.domain.repository;
+
+import com.teamzero.member.domain.model.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+
+    Optional<MemberEntity> findByMemberIdAndEmail(Long memberId, String email);
+}

--- a/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
@@ -3,8 +3,9 @@ package com.teamzero.member.domain.repository;
 import com.teamzero.member.domain.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-
-
+    Optional<Member> findByMemberIdAndEmail(Long memberId, String email);
 }

--- a/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
+++ b/member-api/src/main/java/com/teamzero/member/domain/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.teamzero.member.domain.repository;
+
+import com.teamzero.member.domain.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+
+
+}

--- a/member-api/src/main/java/com/teamzero/member/exception/ErrorCode.java
+++ b/member-api/src/main/java/com/teamzero/member/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.teamzero.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    MEMBER_NOT_FOUND("해당 회원이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+}

--- a/member-api/src/main/java/com/teamzero/member/exception/TeamZeroException.java
+++ b/member-api/src/main/java/com/teamzero/member/exception/TeamZeroException.java
@@ -1,0 +1,15 @@
+package com.teamzero.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TeamZeroException extends RuntimeException {
+
+    ErrorCode errorCode;
+
+    public TeamZeroException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/member-api/src/main/java/com/teamzero/member/filter/MemberFilter.java
+++ b/member-api/src/main/java/com/teamzero/member/filter/MemberFilter.java
@@ -1,0 +1,37 @@
+package com.teamzero.member.filter;
+
+import com.teamzero.domain.JwtAuthenticationProvider;
+import com.teamzero.domain.domain.MemberVo;
+import com.teamzero.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@WebFilter(urlPatterns = "/member/*")
+@RequiredArgsConstructor
+public class MemberFilter implements Filter {
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    private final MemberService memberService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        String token = req.getHeader("X-AUTH-TOKEN");
+
+        if (!jwtAuthenticationProvider.validToken(token)) {
+            throw new ServletException("Invalid Access");
+        }
+
+        MemberVo vo = jwtAuthenticationProvider.getMemberVo(token);
+
+        memberService.findByMemberIdAndEmail(vo.getMemberId(), vo.getEmail());
+
+        chain.doFilter(request, response);
+
+    }
+}

--- a/member-api/src/main/java/com/teamzero/member/service/MemberService.java
+++ b/member-api/src/main/java/com/teamzero/member/service/MemberService.java
@@ -1,0 +1,21 @@
+package com.teamzero.member.service;
+
+import com.teamzero.member.domain.model.Member;
+import com.teamzero.member.domain.repository.MemberRepository;
+import com.teamzero.member.exception.TeamZeroException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import static com.teamzero.member.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findByMemberIdAndEmail(Long memberId, String email) {
+        return memberRepository.findByMemberIdAndEmail(memberId, email)
+                .orElseThrow(() -> new TeamZeroException(MEMBER_NOT_FOUND));
+    }
+
+}

--- a/member-api/src/main/java/com/teamzero/member/service/MemberService.java
+++ b/member-api/src/main/java/com/teamzero/member/service/MemberService.java
@@ -1,0 +1,21 @@
+package com.teamzero.member.service;
+
+import com.teamzero.member.domain.model.MemberEntity;
+import com.teamzero.member.domain.repository.MemberRepository;
+import com.teamzero.member.exception.TeamZeroException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import static com.teamzero.member.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberEntity findByMemberIdAndEmail(Long memberId, String email) {
+        return memberRepository.findByMemberIdAndEmail(memberId, email)
+                .orElseThrow(() -> new TeamZeroException(MEMBER_NOT_FOUND));
+    }
+
+}

--- a/member-api/src/main/resources/application.properties
+++ b/member-api/src/main/resources/application.properties
@@ -9,3 +9,8 @@ spring.datasource.password=1
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create-drop
+
+feign.httpclient.enabled=true
+feign.okhttp.enabled=true
+
+api.kakao.redirect-url=http://localhost:8081/signup/kakao

--- a/product-api/src/main/java/com/teamzero/product/config/GsonConfig.java
+++ b/product-api/src/main/java/com/teamzero/product/config/GsonConfig.java
@@ -1,0 +1,15 @@
+package com.teamzero.product.config;
+
+import com.google.gson.Gson;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GsonConfig {
+
+    @Bean
+    public Gson gson(){
+        return new Gson();
+    }
+
+}

--- a/product-api/src/main/java/com/teamzero/product/domain/model/BaseEntity.java
+++ b/product-api/src/main/java/com/teamzero/product/domain/model/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.teamzero.product.domain.model;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime registeredAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/product-api/src/main/java/com/teamzero/product/domain/model/Product.java
+++ b/product-api/src/main/java/com/teamzero/product/domain/model/Product.java
@@ -1,0 +1,26 @@
+package com.teamzero.product.domain.model;
+
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+public class Product extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+
+
+}

--- a/product-api/src/main/java/com/teamzero/product/domain/model/ProductEntity.java
+++ b/product-api/src/main/java/com/teamzero/product/domain/model/ProductEntity.java
@@ -1,0 +1,24 @@
+package com.teamzero.product.domain.model;
+
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+@Table(name = "PRODUCT")
+public class ProductEntity extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'zeromall'
 include 'member-api'
 include 'product-api'
+include 'teamzero-domain'
 

--- a/teamzero-domain/build.gradle
+++ b/teamzero-domain/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+}

--- a/teamzero-domain/src/main/java/com/teamzero/domain/JwtAuthenticationProvider.java
+++ b/teamzero-domain/src/main/java/com/teamzero/domain/JwtAuthenticationProvider.java
@@ -1,0 +1,63 @@
+package com.teamzero.domain;
+
+import com.teamzero.domain.domain.MemberVo;
+import com.teamzero.domain.util.Aes256Util;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.Objects;
+
+public class JwtAuthenticationProvider {
+
+    private final String SECRET_KEY = "TEAMZERO_ZEROMALL";
+
+    private final long TOKEN_VALID_TIME = 1000L * 60 * 60 * 6;  // 6시간
+
+    public String createToken(String memberId, String email, String role, String grade){
+
+        Claims claims = Jwts.claims()
+                .setId(memberId)
+                .setSubject(Aes256Util.encrypt(email));
+
+        claims.put("role", role);
+        claims.put("grade", grade);
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TOKEN_VALID_TIME))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+
+    }
+
+    public boolean validToken(String token){
+
+        try {
+            Jws<Claims> claimsJws
+                    = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+
+    }
+
+    public MemberVo getMemberVo(String token){
+
+        Claims claims = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
+
+        return MemberVo.builder()
+                .memberId(Long.valueOf(Objects.requireNonNull(claims.getId())))
+                .email(Aes256Util.decrypt(claims.getSubject()))
+                .role(String.valueOf(claims.get("role")))
+                .grade(String.valueOf(claims.get("grade")))
+                .build();
+
+    }
+
+}

--- a/teamzero-domain/src/main/java/com/teamzero/domain/domain/MemberVo.java
+++ b/teamzero-domain/src/main/java/com/teamzero/domain/domain/MemberVo.java
@@ -1,0 +1,17 @@
+package com.teamzero.domain.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberVo {
+
+    private Long memberId;
+    private String email;
+    private String role;
+    private String grade;
+
+}

--- a/teamzero-domain/src/main/java/com/teamzero/domain/util/Aes256Util.java
+++ b/teamzero-domain/src/main/java/com/teamzero/domain/util/Aes256Util.java
@@ -1,0 +1,45 @@
+package com.teamzero.domain.util;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+public class Aes256Util {
+
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String KEY = "TEAMZEROSZEROMALL";
+    private static final String IV = KEY.substring(0, 16);
+
+    public static String encrypt(String text){
+        try{
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            return Base64.encodeBase64String(encrypted);
+        } catch(Exception e) {
+            return null;
+        }
+    }
+
+    public static String decrypt(String cipherText){
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] decodedBytes = Base64.decodeBase64(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch(Exception e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
background
---
- 작업 전 엔터티 및 Gson, Feign 라이브러리 추가
* 클래스 명명 규칙 : 
   : DDD 방식에 맞추어 클래스 명명
   : 엔터티 네이밍 뒤에 Entity를 붙인다.
- 차후 로그인 인증 위해 JWT 필터 작업 필요

change
---
- 기본 엔터티 생성 및 Feign, Gson 라이브러리 추가
- 로그인 인증 위해 JWT 필터 작업

Test
---
- member-api, product-api 실행 후 오류 없는지 확인 완료
- JWT의 경우, 로그인 인증 작업 후 유닛 테스트 예정

Discuss
---
- 금일 회의에서 참조했던 자료 같이 첨부합니다.
- 명명규칙 : https://ozofweird.tistory.com/entry/Java-%EB%AA%85%EB%AA%85-%EA%B7%9C%EC%B9%99
- DDD : https://happycloud-lee.tistory.com/m/94