### PR TITLE
feat : [MEMBER,PRODUCT-SUBSCRIBEANDLIKE] 구독, 좋아요 기능 구현

### DIFF
--- a/product-api/src/main/java/com/teamzero/product/controller/LikeController.java
+++ b/product-api/src/main/java/com/teamzero/product/controller/LikeController.java
@@ -1,0 +1,52 @@
+package com.teamzero.product.controller;
+
+import com.teamzero.product.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/like")
+public class LikeController {
+
+    private final LikeService likeService;
+
+
+    /**
+     * 좋아요 등록
+     */
+    @GetMapping
+    public boolean addLike(@RequestParam String email,
+        @RequestParam Long productId) {
+
+        return likeService.addLike(email, productId);
+
+    }
+
+    /**
+     * 좋아요 조회
+     */
+    @GetMapping
+    public Long getLikes(
+        @RequestParam Long productId) {
+
+        return likeService.likeCount(productId);
+
+    }
+
+    /**
+     * 좋아요 취소
+     */
+    @PutMapping
+    public boolean cancelLike(@RequestParam String email,
+        @RequestParam Long productId) {
+        return likeService.cancelLike(email, productId);
+
+    }
+
+
+}

--- a/product-api/src/main/java/com/teamzero/product/domain/model/LikeEntity.java
+++ b/product-api/src/main/java/com/teamzero/product/domain/model/LikeEntity.java
@@ -1,0 +1,34 @@
+package com.teamzero.product.domain.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+@Table(name = "LIKE")
+@Data
+public class LikeEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long likeId;
+
+    // 상품ID
+    private Long productId;
+
+    // 좋아요 누른 멤버
+    private String memberEmail;
+
+
+}

--- a/product-api/src/main/java/com/teamzero/product/domain/repository/LikeRepository.java
+++ b/product-api/src/main/java/com/teamzero/product/domain/repository/LikeRepository.java
@@ -1,0 +1,15 @@
+package com.teamzero.product.domain.repository;
+
+import com.teamzero.product.domain.model.LikeEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
+
+    Optional<LikeEntity> findByMemberEmailAndProductId(String email,
+        Long productId);
+
+    long countAllByProductId(Long productId);
+
+
+}

--- a/product-api/src/main/java/com/teamzero/product/exception/ErrorCode.java
+++ b/product-api/src/main/java/com/teamzero/product/exception/ErrorCode.java
@@ -28,7 +28,12 @@ public enum ErrorCode {
 
     // 별점 관련 에러 코드
     STAR_MEMBER_NOT_FOUND("해당 회원이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
-    STAR_SCORE_RANGE_NOT_VALID("별점은 1점 ~ 5점 사이로만 등록 가능합니다.", HttpStatus.BAD_REQUEST);
+    STAR_SCORE_RANGE_NOT_VALID("별점은 1점 ~ 5점 사이로만 등록 가능합니다.", HttpStatus.BAD_REQUEST),
+
+    // 좋아요 관련 에러 코드
+    LIKE_MEMBER_NOT_FOUND("해당 회원이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    LIKE_ALREADY_LIKED("이미 좋아요를 누른 상품입니다.", HttpStatus.BAD_REQUEST),
+    LIKE_ALREADY_UNLIKED("이미 좋아요를 취소한 상품입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/product-api/src/main/java/com/teamzero/product/service/LikeService.java
+++ b/product-api/src/main/java/com/teamzero/product/service/LikeService.java
@@ -1,0 +1,97 @@
+package com.teamzero.product.service;
+
+import static com.teamzero.product.exception.ErrorCode.LIKE_ALREADY_LIKED;
+import static com.teamzero.product.exception.ErrorCode.LIKE_ALREADY_UNLIKED;
+import static com.teamzero.product.exception.ErrorCode.LIKE_MEMBER_NOT_FOUND;
+import static com.teamzero.product.exception.ErrorCode.PRODUCT_NOT_FOUND;
+
+import com.teamzero.member.domain.repository.MemberRepository;
+import com.teamzero.product.domain.model.LikeEntity;
+import com.teamzero.product.domain.repository.LikeRepository;
+import com.teamzero.product.domain.repository.ProductRepository;
+import com.teamzero.product.exception.TeamZeroException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    private final ProductRepository productRepository;
+
+    private final MemberRepository memberRepository;
+
+
+    /**
+     * 좋아요 등록
+     */
+    public boolean addLike(String email, Long productId) {
+        // 회원 정보와 상품정보 유효한지 확인(고은님코드 참고하였습니다)
+        validateRequest(email, productId);
+
+        // 해당 회원이 좋아요를 누른 상품인지 확인 후, 이미 좋아요 누른 상품이면 오류반환
+        Optional<LikeEntity> optionalLike
+            = likeRepository.findByMemberEmailAndProductId(email, productId);
+
+        if (!optionalLike.isPresent()) {
+            likeRepository.save(
+                LikeEntity.builder()
+                    .productId(productId)
+                    .memberEmail(email)
+                    .build()
+            );
+            return true;
+        } else {
+            throw new TeamZeroException(LIKE_ALREADY_LIKED);
+        }
+    }
+
+    /**
+     * 좋아요 조회 - 상품 ID를 받아서 좋아요 갯수 반환
+     */
+    public Long likeCount(Long productId) {
+
+        return likeRepository.countAllByProductId(productId);
+
+    }
+
+    /**
+     * 좋아요 취소
+     */
+    public boolean cancelLike(String email, Long productId) {
+        // 회원 정보와 상품정보 유효한지 확인(고은님코드 참고하였습니다)
+        validateRequest(email, productId);
+
+        // 해당 회원이 좋아요를 누른 상품인지 확인 후 이미 좋아요 취소한 상품이면 오류반환
+        Optional<LikeEntity> optionalLike
+            = likeRepository.findByMemberEmailAndProductId(email, productId);
+
+        if (optionalLike.isPresent()) {
+            likeRepository.deleteById(optionalLike.get().getLikeId());
+            return true;
+        } else {
+            throw new TeamZeroException(LIKE_ALREADY_UNLIKED);
+        }
+
+    }
+
+    /**
+     * 회원 정보와 상품정보 유효한지 확인
+     */
+    private void validateRequest(String email, Long productId) {
+        // 회원 존재 여부 확인
+        if (!memberRepository.existsByEmail(email)) {
+            throw new TeamZeroException(LIKE_MEMBER_NOT_FOUND);
+        }
+
+        // 상품 존재 여부 확인
+        if (!productRepository.existsByProductId(productId)) {
+            throw new TeamZeroException(PRODUCT_NOT_FOUND);
+        }
+
+    }
+
+}

--- a/product-api/src/test/java/com/teamzero/product/service/LikeServiceTest.java
+++ b/product-api/src/test/java/com/teamzero/product/service/LikeServiceTest.java
@@ -1,0 +1,133 @@
+package com.teamzero.product.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.teamzero.member.domain.repository.MemberRepository;
+import com.teamzero.product.domain.model.LikeEntity;
+import com.teamzero.product.domain.repository.LikeRepository;
+import com.teamzero.product.domain.repository.ProductRepository;
+import com.teamzero.product.exception.TeamZeroException;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Test
+    @DisplayName("상품 좋아요 테스트")
+    void addLike() {
+
+        // given
+        String email = "test1@gmail.com";
+        Long productId = 1L;
+
+        given(memberRepository.existsByEmail(anyString()))
+            .willReturn(true);
+
+        given(productRepository.existsByProductId(anyLong()))
+            .willReturn(true);
+
+        // when
+        boolean response = likeService.addLike(email, productId);
+
+        // then
+        Assertions.assertEquals(true, response);
+
+    }
+
+    @Test
+    @DisplayName("상품 좋아요 중복 테스트")
+    void addTwiceLike() {
+
+        // given
+        String email = "test1@gmail.com";
+        Long productId = 1L;
+
+        given(memberRepository.existsByEmail(anyString()))
+            .willReturn(true);
+
+        given(productRepository.existsByProductId(anyLong()))
+            .willReturn(true);
+
+        given(likeRepository.findByMemberEmailAndProductId(anyString(),
+            anyLong()))
+            .willReturn(Optional.of(
+                LikeEntity.builder()
+                    .likeId(1L)
+                    .memberEmail(email)
+                    .build()
+            ));
+
+        // then
+        Assertions.assertThrows(TeamZeroException.class, () -> {
+            likeService.addLike(email, productId);
+        });
+
+
+    }
+
+    @Test
+    @DisplayName("상품 좋아요 갯수 테스트")
+    void countLikes() {
+
+        // given
+        given(likeRepository.countAllByProductId(anyLong()))
+            .willReturn(123L);
+
+        // when
+        Long response = likeService.likeCount(1L);
+
+        // then
+        Assertions.assertEquals(123L, response);
+
+    }
+
+    @Test
+    @DisplayName("상품 좋아요 취소 테스트")
+    void cancelLike() {
+
+        // given
+        String email = "test1@gmail.com";
+        Long productId = 1L;
+
+        given(memberRepository.existsByEmail(anyString()))
+            .willReturn(true);
+
+        given(productRepository.existsByProductId(anyLong()))
+            .willReturn(true);
+        given(likeRepository.findByMemberEmailAndProductId(anyString(),
+            anyLong()))
+            .willReturn(Optional.of(
+                LikeEntity.builder()
+                    .likeId(1L)
+                    .memberEmail(email)
+                    .build()
+            ));
+        // when
+        boolean response = likeService.cancelLike(email, productId);
+
+        // then
+        Assertions.assertEquals(true, response);
+
+    }
+}

--- a/user-api/src/main/java/com/teamzero/member/controller/MemberController.java
+++ b/user-api/src/main/java/com/teamzero/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,9 +36,9 @@ public class MemberController {
      * 회원 탈퇴
      */
     @PutMapping("/withdraw")
-    public ResponseEntity<?> withdrawMember(@RequestBody Modify member) {
-        var withdrawResult = memberService.withdrawMember(member);
-        return ResponseEntity.ok(withdrawResult);
+    public boolean withdrawMember(@RequestParam String email) {
+
+        return memberService.withdrawMember(email);
     }
 
     /**

--- a/user-api/src/main/java/com/teamzero/member/controller/SubscribeController.java
+++ b/user-api/src/main/java/com/teamzero/member/controller/SubscribeController.java
@@ -1,0 +1,52 @@
+package com.teamzero.member.controller;
+
+import com.teamzero.member.service.SubscribeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/subscribe")
+public class SubscribeController {
+
+    private final SubscribeService subscribeService;
+
+
+    /**
+     * 구독
+     */
+    @GetMapping("/add")
+    public boolean addSubscribe(@RequestParam String email,
+        @RequestParam String grade) {
+
+        return subscribeService.addSubscribe(email, grade);
+    }
+
+    /**
+     * 구독 변경
+     */
+    @GetMapping("/modify")
+    public boolean modifySubscribe(@RequestParam String email,
+        @RequestParam Long subscribeId, @RequestParam String grade) {
+
+        return subscribeService.modifySubscribe(email, subscribeId, grade);
+
+    }
+
+    /**
+     * 구독 취소
+     */
+    @PutMapping("/cancel")
+    public boolean cancelSubscribe(@RequestParam String email,
+        @RequestParam Long subscribeId) {
+
+        return subscribeService.cancelSubscribe(email, subscribeId);
+
+    }
+
+
+}

--- a/user-api/src/main/java/com/teamzero/member/domain/model/MemberEntity.java
+++ b/user-api/src/main/java/com/teamzero/member/domain/model/MemberEntity.java
@@ -42,4 +42,8 @@ public class MemberEntity extends BaseEntity{
     @Audited
     private long currentPoint;
 
+    // 구독 관련
+    private boolean subscribeYn;
+    private LocalDateTime subscribedAt;
+
 }

--- a/user-api/src/main/java/com/teamzero/member/exception/ErrorCode.java
+++ b/user-api/src/main/java/com/teamzero/member/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     MEMBER_STATUS_NOT_EXIST("해당 회원 상태는 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_DATA_NOT_FOUND("검색 결과 데이터가 없습니다.", HttpStatus.BAD_REQUEST),
     PRODUCT_NOT_FOUND("해당 상품이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
-    TOKEN_NOT_VALID("토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+    TOKEN_NOT_VALID("토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    SUBSCRIBE_TASK_CAN_NOT_BE_DONE("구독작업을 완료 할 수 없습니다",HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/user-api/src/main/java/com/teamzero/member/service/MemberService.java
+++ b/user-api/src/main/java/com/teamzero/member/service/MemberService.java
@@ -68,6 +68,8 @@ public class MemberService {
                 .memberStatus(MemberStatus.NO_AUTH)
                 .emailAuthKey(emailAuthKey)
                 .emailAuthYn(false)
+            //구독여부 초기값 추가하였습니다.
+                .subscribeYn(false)
                 .build();
 
         memberRepository.save(member);
@@ -152,19 +154,19 @@ public class MemberService {
      * 회원 탈퇴
      */
     @Transactional
-    public MemberEntity withdrawMember(Modify member) {
+    public boolean withdrawMember(String email) {
 
-        if (!isMemberExist(member.getMemberId())) {
+        if (memberRepository.findByEmail(email).isEmpty()) {
             throw new TeamZeroException(MEMBER_NOT_FOUND);
         }
 
-        MemberEntity memberEntity = memberRepository.findById(member.getMemberId()).get();
+        MemberEntity memberEntity = memberRepository.findByEmail(email).get();
 
         memberEntity.setMemberStatus(MemberStatus.WITHDRAW);
 
         memberRepository.save(memberEntity);
 
-        return memberEntity;
+        return true;
     }
 
 

--- a/user-api/src/main/java/com/teamzero/member/service/SubscribeService.java
+++ b/user-api/src/main/java/com/teamzero/member/service/SubscribeService.java
@@ -1,0 +1,106 @@
+package com.teamzero.member.service;
+
+import static com.teamzero.member.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.teamzero.member.domain.model.MemberEntity;
+import com.teamzero.member.domain.model.MemberGradeEntity;
+import com.teamzero.member.domain.repository.MemberGradeRepository;
+import com.teamzero.member.domain.repository.MemberRepository;
+import com.teamzero.member.exception.ErrorCode;
+import com.teamzero.member.exception.TeamZeroException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeService {
+
+    private final MemberRepository memberRepository;
+    private final MemberGradeRepository memberGradeRepository;
+
+    /**
+     * 구독 등록
+     * @param email
+     * @param grade
+     * @return
+     */
+    @Transactional
+    public boolean addSubscribe(String email, String grade) {
+        boolean result = false;
+        //TODO 결제 성공시 진행
+        try {
+            // 결제 성공시 회원조회하여 등급수정
+            MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new TeamZeroException(MEMBER_NOT_FOUND));
+            member.setMemberGradeEntity(
+                MemberGradeEntity.builder()
+                    .member(member)
+                    .name(grade)
+                    .build());
+            member.setSubscribedAt(LocalDateTime.now());
+            member.setSubscribeYn(true);
+            memberRepository.save(member);
+            result = true;
+        } catch (TeamZeroException e) {
+            new TeamZeroException(ErrorCode.SUBSCRIBE_TASK_CAN_NOT_BE_DONE);
+        }
+        return result;
+    }
+
+    /**
+     * 구독 수정
+     * @param email
+     * @param subscribeId
+     * @param grade
+     * @return
+     */
+    @Transactional
+    public boolean modifySubscribe(String email, Long subscribeId,
+        String grade) {
+        boolean result = false;
+        //TODO 결제 성공시 진행
+        try {
+            // 결제 성공시 회원조회하여 등급수정
+            MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new TeamZeroException(MEMBER_NOT_FOUND));
+            MemberGradeEntity memberGrade = memberGradeRepository.findById(
+                    subscribeId)
+                .orElseThrow(() -> new TeamZeroException(
+                    ErrorCode.MEMBER_GRADE_NOT_FOUND));
+            memberGrade.setName(grade);
+            member.setMemberGradeEntity(memberGrade);
+            member.setSubscribedAt(LocalDateTime.now());
+            memberRepository.save(member);
+            result = true;
+        } catch (TeamZeroException e) {
+            new TeamZeroException(ErrorCode.SUBSCRIBE_TASK_CAN_NOT_BE_DONE);
+        }
+        return result;
+    }
+
+    /**
+     * 구독 취소
+     * @param email
+     * @param subscribeId
+     * @return
+     */
+    @Transactional
+    public boolean cancelSubscribe(String email, Long subscribeId) {
+        boolean result = false;
+        try {
+            // 회원조회하여 구독여부 false로 설정 후 MemberGradeEntity 삭제 처리
+            MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new TeamZeroException(MEMBER_NOT_FOUND));
+            memberGradeRepository.deleteById(subscribeId);
+            member.setSubscribeYn(false);
+            member.setSubscribedAt(null);
+            memberRepository.save(member);
+            result = true;
+        } catch (TeamZeroException e) {
+            new TeamZeroException(ErrorCode.SUBSCRIBE_TASK_CAN_NOT_BE_DONE);
+        }
+        return result;
+    }
+}

--- a/user-api/src/test/java/com/teamzero/member/service/SubscribeServiceTest.java
+++ b/user-api/src/test/java/com/teamzero/member/service/SubscribeServiceTest.java
@@ -1,0 +1,128 @@
+package com.teamzero.member.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.teamzero.member.domain.model.MemberEntity;
+import com.teamzero.member.domain.model.MemberGradeEntity;
+import com.teamzero.member.domain.model.constants.MemberStatus;
+import com.teamzero.member.domain.repository.MemberGradeRepository;
+import com.teamzero.member.domain.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscribeServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberGradeRepository memberGradeRepository;
+
+    @InjectMocks
+    private SubscribeService subscribeService;
+
+    @Test
+    @DisplayName("구독하기")
+    void addSubscribe() {
+        //given
+        String email = "test@gmail.com";
+        String grade = "PREMIUM";
+        MemberEntity member = MemberEntity.builder()
+            .memberId(1L)
+            .email("test@gmail.com")
+            .memberGradeEntity(MemberGradeEntity.builder()
+                .id(1L)
+                .name("BASIC")
+                .rewardPointPct(0).build())
+            .memberStatus(MemberStatus.IN_USE)
+            .build();
+
+        given(memberRepository.findByEmail(email))
+            .willReturn(Optional.of(member));
+
+        // when
+        boolean result = subscribeService.addSubscribe(member.getEmail(),
+            grade);
+
+        // then
+        Assertions.assertEquals(true, result);
+
+    }
+
+    @Test
+    @DisplayName("구독 수정")
+    void modifySubscribe() {
+
+        // given
+        MemberEntity member = MemberEntity.builder()
+            .memberId(1L)
+            .email("test@gmail.com")
+            .memberGradeEntity(MemberGradeEntity.builder()
+                .id(1L)
+                .name("BASIC")
+                .rewardPointPct(0).build())
+            .memberStatus(MemberStatus.IN_USE)
+            .build();
+        MemberGradeEntity memberGrade = MemberGradeEntity.builder()
+            .id(1L)
+            .member(member)
+            .name("SILVER")
+            .rewardPointPct(1)
+            .build();
+        String grade = "PREMIUM";
+
+        given(memberRepository.findByEmail(member.getEmail()))
+            .willReturn(Optional.of(member));
+        given(memberGradeRepository.findById(anyLong()))
+            .willReturn(Optional.of(memberGrade));
+
+        // when
+        boolean result = subscribeService.modifySubscribe(member.getEmail(), 1L,
+            grade);
+
+        // then
+        Assertions.assertEquals(true, result);
+
+    }
+
+    @Test
+    @DisplayName("구독 취소")
+    void cancelSubscribe() {
+
+        // given
+        MemberEntity member = MemberEntity.builder()
+            .memberId(1L)
+            .email("test@gmail.com")
+            .memberGradeEntity(MemberGradeEntity.builder()
+                .id(1L)
+                .name("BASIC")
+                .rewardPointPct(0).build())
+            .memberStatus(MemberStatus.IN_USE)
+            .build();
+        MemberGradeEntity memberGrade = MemberGradeEntity.builder()
+            .id(1L)
+            .member(member)
+            .name("BASIC")
+            .rewardPointPct(1)
+            .build();
+
+        given(memberRepository.findByEmail(member.getEmail()))
+            .willReturn(Optional.of(member));
+
+        // when
+        boolean result = subscribeService.cancelSubscribe(member.getEmail(),
+            memberGrade.getId());
+
+        // then
+        Assertions.assertEquals(true, result);
+
+    }
+}


### PR DESCRIPTION

change
---
- 구독 기능 service,controller 구현
- 좋아요 기능 entity,repository,service,controller 구현
- errorcode 추가
- MemberController, MemberSevice 내 회원탈퇴기능 피드백 반영
- MemberSevice 회원가입에 구독여부 초기 값 추가
- MemberEntity 내 구독여부,구독시작일 추가

Test
---
- 구독, 좋아요 기능 unit 테스트 통과

